### PR TITLE
Tdubiel/v6.8/update scalaspark versions interset

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,12 +19,14 @@ jacksonVersion = 1.8.8
 cascadingVersion = 2.6.3
 # Spark
 spark13Version = 1.6.2
-spark20Version = 2.3.0
+spark20Version = 2.4.4
 # same as Spark's
 scala210Version = 2.10.7
 scala210MajorVersion = 2.10
 scala211Version = 2.11.12
 scala211MajorVersion = 2.11
+scala212Version = 2.12.10
+scala212MajorVersion = 2.12
 
 stormVersion = 1.0.6
 

--- a/install_local.sh
+++ b/install_local.sh
@@ -4,7 +4,7 @@ set -e
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
 echo "Building es-hadoop jars with gradlew..."
-sh ${PROJECT_ROOT}/gradlew
+sh ${PROJECT_ROOT}/gradlew distZip
 
 # JAR and pom file 
 JAR="${PROJECT_ROOT}/build/distributions/elasticsearch-hadoop-6.8.12-SNAPSHOT/dist/elasticsearch-spark-20_2.12-6.8.12-SNAPSHOT.jar"

--- a/install_local.sh
+++ b/install_local.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+echo "Building es-hadoop jars with gradlew..."
+sh ${PROJECT_ROOT}/gradlew
+
+# JAR and pom file 
+JAR="${PROJECT_ROOT}/build/distributions/elasticsearch-hadoop-6.8.12-SNAPSHOT/dist/elasticsearch-spark-20_2.12-6.8.12-SNAPSHOT.jar"
+
+#   These should match the existing maven dependency
+# for the artifact you're pulling from repo
+GROUP_ID="org.elasticsearch"
+ARTIFACT_ID="elasticsearch-spark-20_2.12"
+VERSION="6.8.12-SNAPSHOT"
+
+echo "INSTALLING JAR FILE: ${JAR}"
+echo "    [group].[artifact]-[version]: ${GROUP_ID}.${ARTIFACT_ID}-${VERSION}"
+echo "INSTALLING POM FILE: ${POM}"
+
+mvn install:install-file \
+    -Dfile=${JAR} \
+    -DgroupId=${GROUP_ID} \
+    -DartifactId=${ARTIFACT_ID} \
+    -Dversion=${VERSION} \
+    -Dpackaging=jar

--- a/spark/core/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
+++ b/spark/core/main/scala/org/elasticsearch/spark/rdd/EsRDDWriter.scala
@@ -64,7 +64,10 @@ private[spark] class EsRDDWriter[T: ClassTag](val serializedSettings: String,
   def write(taskContext: TaskContext, data: Iterator[T]) {
     val writer = RestService.createWriter(settings, taskContext.partitionId.toLong, -1, log)
 
-    taskContext.addTaskCompletionListener((TaskContext) => writer.close())
+    taskContext.addTaskCompletionListener(TaskContext => {
+      writer.close()
+      Unit
+    })
 
     if (runtimeMetadata) {
       writer.repository.addRuntimeFieldExtractor(metaExtractor)

--- a/spark/sql-20/build.gradle
+++ b/spark/sql-20/build.gradle
@@ -8,8 +8,8 @@ apply plugin: 'es.hadoop.build.integration'
 apply plugin: 'scala.variants'
 
 variants {
-    defaultVersion '2.11.12'
-    targetVersions '2.10.7', '2.11.12'
+    defaultVersion '2.12.10'
+    targetVersions '2.10.7', '2.11.12', '2.12.10'
 }
 
 println "Compiled using Scala ${project.ext.scalaMajorVersion} [${project.ext.scalaVersion}]"


### PR DESCRIPTION
# Motivation
Interset Analytics needed to be bumped up to Scala 2.12 and Spark 2.4.4. Analytics is run on numerous platforms but we want to keep the same codebase, instead of maintaining 3 different branches.

To this end we need to find a way to get Interset Analytics and all of it's dependencies working on matching versions.

There was a discussion in the official es-hadoop repo about this:
https://github.com/elastic/elasticsearch-hadoop/pull/1308

But in lieu of a hasty solution, they've decided to overhaul their cross compilation.
https://github.com/elastic/elasticsearch-hadoop/issues/1423

We need this resolved for a release that is coming up. We have the hasty solution in hand and its passed dev testing.

# Plan
The plan is to develop a pipeline to build and deploy this to our artifactory.

As soon as the official repo gets cross compilations rolled out, we can go to just mirroring the official builds.