### PR TITLE
Skip building snapshot for now

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,7 +27,7 @@ if (qualifier.isEmpty() == false) {
 }
 
 // determine if we're building a snapshot or not (by default we will be)
-boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"))
+boolean snapshot = "true".equals(System.getProperty("build.snapshot", "false"))
 if (snapshot) {
     // we update the version property to reflect if we are building a snapshot or a release build
     eshVersion += "-SNAPSHOT"


### PR DESCRIPTION
As the build tool version is missing in the upstream artifactory for this branch:


`
FAILURE: Build failed with an exception.
What went wrong:
Execution failed for task ':buildSrc:compileGroovy'.
 Could not resolve all files for configuration ':buildSrc:compileClasspath'.
    Could not resolve org.elasticsearch.gradle:build-tools:7.6.2-SNAPSHOT.
     Required by:
         project :buildSrc
       Could not resolve org.elasticsearch.gradle:build-tools:7.6.2-SNAPSHOT.
          Unable to load Maven meta-data from https://oss.sonatype.org/content/repositories/snapshots/org/elasticsearch/gradle/build-tools/7.6.2-SNAPSHOT/maven-metadata.xml.
             Could not get resource 'https://oss.sonatype.org/content/repositories/snapshots/org/elasticsearch/gradle/build-tools/7.6.2-SNAPSHOT/maven-metadata.xml'.
                Could not GET 'https://oss.sonatype.org/content/repositories/snapshots/org/elasticsearch/gradle/build-tools/7.6.2-SNAPSHOT/maven-metadata.xml'. Received status code 403 from server: Forbidden
`

So, as discussed in the Jira task: https://filetrek.atlassian.net/browse/OPS-398

We will skip building snapshot for now.